### PR TITLE
Fix: Resolve missing import for FeaturedGuides component

### DIFF
--- a/fair-repair/src/components/sections/FeaturedGuides.tsx
+++ b/fair-repair/src/components/sections/FeaturedGuides.tsx
@@ -1,0 +1,18 @@
+// components/sections/FeaturedGuides.tsx
+import { getAllContentMetadata } from '@/lib/content'; // Corrected import
+import React from 'react';
+
+// Placeholder component
+const FeaturedGuides = () => {
+  // In a real component, you would fetch and display guides
+  // For now, this is a placeholder to ensure the import is correct
+  console.log('FeaturedGuides component rendered, imported getAllContentMetadata');
+  return (
+    <div>
+      <h2>Featured Guides</h2>
+      {/* Placeholder content */}
+    </div>
+  );
+};
+
+export default FeaturedGuides;


### PR DESCRIPTION
The component `src/components/sections/FeaturedGuides.tsx` was referenced by the build process but did not exist, causing an import error related to `getAllContentMetadataForLists` from a non-existent `@/lib/markdown` module.

This commit:
- Creates `fair-repair/src/components/sections/FeaturedGuides.tsx`.
- Corrects the import to use `getAllContentMetadata` from `@/lib/content`.
- Implements a basic placeholder structure for the component.

This resolves the specific build error and allows the homepage to render without crashing due to this missing module and incorrect import.